### PR TITLE
Include generic pgmspace.h

### DIFF
--- a/src/fix_fft.h
+++ b/src/fix_fft.h
@@ -1,6 +1,11 @@
 #ifndef FIXFFT_H
 #define FIXFFT_H
-#include <avr/pgmspace.h>
+
+#if (defined(__AVR__))
+#include <avr\pgmspace.h>
+#else
+#include <pgmspace.h>
+#endif
 
 #if ARDUINO >= 100
 	#include "Arduino.h"


### PR DESCRIPTION
This should eliminate the "avr/pgmspace.h: No such file or directory" error I was getting when compiling for 32-bit processors that don't use AVR. I tested it on the STM32F103 and ESP32, and both work if I deal with their 12-bit analog readings.